### PR TITLE
More resilient Fallback Mode

### DIFF
--- a/aiscripts/lib.request.orders.xml
+++ b/aiscripts/lib.request.orders.xml
@@ -10,20 +10,6 @@ Do:
 4. If [2] returns true, also updates the wing name appropriately
 -->
 <diff>
-    <add sel="/aiscript[@name='lib.request.orders']/attention/actions/do_else/do_else" pos="before">
-        <do_elseif value="(not global.$v1024_flags_hasRightClickAPI) and (($object.primarypurpose == purpose.trade and $commander.type != shiptype.resupplier) or $object.primarypurpose == purpose.mine)">
-            <!-- If we are in fallback mode, -->
-            <!-- We must seize the means of production before the military does the same. -->
-            <do_if value="$object.isplayerowned" comment="Ignore non-player ships to boost performance">
-                <show_help position="1" duration="6s" custom="'Signalling the previous-made handler.'" chance="0"/>
-                <set_value name="$flag_v1024_civfleetformed" exact="true" comment="Actual value not important." />
-                <!-- Delegate to standardized static config method to ensure save-game compatibility. -->
-                <signal_objects object="player.galaxy" param="global.$v1024_symbols_requestOrderSync" param2="$commander" param3="$object" />
-            </do_if>
-        </do_elseif>
-        <!-- Normal assign-to-defend code follows this block of code. -->
-    </add>
-
     <add sel="/aiscript[@name='lib.request.orders']/attention/actions/do_else/do_else/do_else" pos="before">
         <!-- At this point, definitely assigning to another ship, no need to double-check. -->
 
@@ -32,7 +18,7 @@ Do:
         <show_help position="1" duration="2s" custom="'Test 1 ' + (global.$v1024_flags_hasRightClickAPI == 0)"/>
         <show_help position="1" duration="2s" custom="'Test 2 ' + (global.$v1024_flags_hasRightClickAPI == false)"/>
         -->
-        <!-- Case: Right Click API successfully loaded and assigning ships to civilian fleets -->
+        <!-- Case: Assigning ships to civilian fleets; Right Click API-related mess is already handled in order.assign.commander. -->
         <do_elseif value="$assignment == assignment.trade or $assignment == assignment.mining">
             <do_if value="$object.isplayerowned" comment="Ignore non-player ships to boost performance">
                 <show_help position="1" duration="6s" custom="'Signalling the previous-made handler.'" chance="0"/>

--- a/aiscripts/order.assign.commander.xml
+++ b/aiscripts/order.assign.commander.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- 
+Basically the Fallback Mode.
+
+Whenever a ship is assigned to another commander...
+1. When Right Click API cannot be loaded
+Do:
+1. Check if the commander-to-be is a ship.
+2. Check if both the commander-to-be and the subordinate-to-be have the same primary purpose
+3. If [2] returns true, set the assignment to a value recognized by our other scripts (assignment.trade or assignment.mining)
+-->
+<diff>
+    <add sel="/aiscript[@name='order.assign.commander']/attention/actions/do_if[1]" pos="prepend">
+        <!-- Super early checking. -->
+        <!-- Also ignore non-player ships for performance. -->
+        <do_if value="not global.$v1024_flags_hasRightClickAPI and $commander.isplayerowned">
+            <!-- Right click API not loaded. Prerequisite 1 satisfied. -->
+            <!-- Check 1. -->
+            <do_if value="$commander.isclass.[class.ship]">
+                <!-- Is 1. Now check 2. -->
+                <set_value name="$thisship" exact="this.object" />
+                <do_if value="$commander.primarypurpose == $thisship.primarypurpose">
+                    <!-- Is 2. Now do 3. -->
+                    <do_if value="$commander.primarypurpose == purpose.trade">
+                        <set_value name="$assignment" exact="assignment.trade" />
+                    </do_if>
+                    <do_elseif value="$commander.primarypurpose == purpose.mine">
+                        <set_value name="$assignment" exact="assignment.mining" />
+                    </do_elseif>
+                    <do_else>
+                        <!-- Not relevant to us. -->
+                    </do_else>
+                </do_if>
+            </do_if>
+        </do_if>
+        <!-- We have done all we want to do. Pass back to vanilla handling. -->
+    </add>
+</diff>

--- a/content.xml
+++ b/content.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <content name="V1024 - Civilian Fleets" id="v1024_civilian_fleets" author="Vectorial1024" version="200" date="2019-08-06" save="0" description="Create civilian fleets to help manage traders and miners.">
-    <!-- Force the dependency again since v3.0 has now stabilized. -->
-    <!-- Eventually we should somehow shift away from RightClickAPI and adopt SirNukes API completely -->
+    <!-- Remove dependency. At this point I'd rather make an announcement when the user do not have Right Click API. -->
+    <!--
     <dependency id="RightClickAPI" />
+    -->
     <!-- Dependent on SirNukes API; any version should do. -->
     <dependency id="ws_2042901274" />
 </content>

--- a/md/civilianfleets_signals.xml
+++ b/md/civilianfleets_signals.xml
@@ -104,7 +104,7 @@ You gotta pick the variables back up after usage!
                 <edit_order_param order="$toShip_DefaultOrder" param="'maxbuy'" value="$maxBuy" />
                 <edit_order_param order="$toShip_DefaultOrder" param="'maxsell'" value="$maxSell" />
                 -->
-                <do_if value="$toShip.assignment == assignment.mining or ((not global.$v1024_flags_hasRightClickAPI) and $fromShip.primarypurpose == purpose.mine and $toShip.primarypurpose == purpose.mine)">
+                <do_if value="$toShip.assignment == assignment.mining">
                     <show_help position="1" duration="1s" custom="'Mining! ' + $fromShip.name + ' -> ' + $toShip.name" chance="0"/>
                     <do_if value="not global.$v1024_flags_hasRightClickAPI" comment="Fallback mode code">
                         <set_object_commander object="$toShip" commander="$fromShip" assignment="assignment.mining"/>
@@ -240,7 +240,7 @@ You gotta pick the variables back up after usage!
                         </create_order>
                     </do_else>
                 </do_if>
-                <do_elseif value="$toShip.assignment == assignment.trade or ((not global.$v1024_flags_hasRightClickAPI) and $fromShip.primarypurpose == purpose.trade and $toShip.primarypurpose == purpose.trade)">
+                <do_elseif value="$toShip.assignment == assignment.trade">
                     <show_help position="1" duration="1s" custom="'Trading! ' + $fromShip.name + ' -> ' + $toShip.name" chance="0"/>
                     <do_if value="not global.$v1024_flags_hasRightClickAPI" comment="Fallback mode code">
                         <set_object_commander object="$toShip" commander="$fromShip" assignment="assignment.trade"/>

--- a/md/v1024_civilian_fleets.xml
+++ b/md/v1024_civilian_fleets.xml
@@ -106,7 +106,7 @@
       <conditions>
         <event_cue_signalled cue="md.Setup.Start" />
       </conditions>
-      <delay exact="10s" comment="Similar situation compared to the Right Click API situation." />
+      <delay exact="15s" comment="Similar situation compared to the Right Click API situation." />
       <actions>
         <!-- SirNukes announcement. -->
 

--- a/md/v1024_civilian_fleets.xml
+++ b/md/v1024_civilian_fleets.xml
@@ -90,15 +90,14 @@
         <do_if value="not global.$v1024_flags_hasRightClickAPI">
           <!-- If the game is starting, but still no Right Click API detected: assume no such mod is loaded, and activate fallback mode.-->
           
-          <show_help position="1" duration="6s" custom="'V1024-CF: Civilian Fleets failed to detect Right Click API. Fallback Mode engaged.'"/>
-          <show_help position="1" duration="6s" custom="'V1024-CF: Use [(Default Role) Defend] to form/join civilian fleets instead.'"/>
-          <show_help position="1" duration="6s" custom="'V1024-CF: Existing civilian fleets will still function normally.'"/>
-          <show_help position="1" duration="6s" custom="'V1024-CF: Fallback Mode changes some rules about civilian fleet forming/joining:'"/>
-          <show_help position="1" duration="6s" custom="'V1024-CF: Changed rule (1): Mining fleets can only accept ships with primary purpose = mine.'"/>
-          <show_help position="1" duration="6s" custom="'V1024-CF: Changed rule (2): Trading fleets can only accept ships with primary purpose = trade.'"/>
-          <show_help position="1" duration="6s" custom="'V1024-CF: This means, fight ships can no longer work for any civilian fleets.'"/>
-          <show_help position="1" duration="6s" custom="'V1024-CF: Of course, fight ships already working for existing civilian fleets are not affeected.'"/>
+          <show_help position="1" duration="6s" custom="'V1024-CF: Civilian Fleets did not detect Right Click API. Fallback Mode engaged.'"/>
+          <show_help position="1" duration="6s" custom="'V1024-CF: Use [Defend >], [Attack >], or [Intercept >] to form/join civilian fleets instead.'"/>
+          <show_help position="1" duration="6s" custom="'V1024-CF: Refer to Logbook -> Tips for more info.'"/>
           <show_help position="1" duration="6s" custom="'V1024-CF: This is the end of the Fallback Mode announcement.'"/>
+
+          <!-- Delegate to Logbook for less cluttering. -->
+          <set_value name="$logtext" exact="'Civilian Fleets did not detect Right Click API. Fallback Mode engaged. Use [Defend >], [Attack >], or [Intercept >] to form/join civilian fleets instead.\n\nThere are some changes in how this mod works under the Fallback Mode:\n0. Existing civilian fleets are not affected.\n1. Mining fleets can only accept ships with primary purpose = mine.\n2. Trading fleets can only accept ships with primary purpose = trade.\n3. Fighting ships are not eligible of joining civilian fleets.\n\nOf course, this mod works best with Right Click API, but if the situation demands that Right Click API be removed, then we shall comply as much as we can.'" />
+          <write_to_logbook category="tips" title="'V1024 Civilian Fleets: Fallback Mode'" text="$logtext" />
         </do_if>
         <show_help position="1" duration="10s" custom="'Right click API flag set to: ' + global.$v1024_flags_hasRightClickAPI" chance="0"/>
       </actions>


### PR DESCRIPTION
- Now, when in Fallback Mode, force assignment to trader/miner at the moment the assignment takes place, not during order sync
- Removed safety checks in order sync since we now use the usual trader/miner assignment trick even in Fallback Mode. Users should reset the fleets on their own if there are problems
- Reduced cluttering of Fallback Mode announcements
- Removed explicit requirement of Right Click API; that mod is now recommended but not required so that I can sleep peacefully when another beta comes in