### PR TITLE
Add global variable that indicates mod status

### DIFF
--- a/md/civilianfleets_signals.xml
+++ b/md/civilianfleets_signals.xml
@@ -19,6 +19,9 @@ You gotta pick the variables back up after usage!
                 <do_if value="not (global.$v1024cf_should_rename_fleets?)">
                     <set_value name="global.$v1024cf_should_rename_fleets" exact ="true" />
                 </do_if>
+
+                <!-- indicate that we have loaded our mod successfully. -->
+                <set_value name="global.$v1024cf_mod_loaded" exact ="true" />
             </actions>
         </cue>
 


### PR DESCRIPTION
Useful for other mods to detect if Civilian Fleets is loaded.

An intermediate step to address #14.