### PR TITLE
Enforce initial renaming for fresh civilian fleets

### DIFF
--- a/aiscripts/order.assign.commander.xml
+++ b/aiscripts/order.assign.commander.xml
@@ -38,11 +38,15 @@ Do:
             <!-- Assigning to ship. -->
             <do_if value="($assignmentObj == assignment.trade and $commanderObject.type != shiptype.resupplier) or $assignmentObj == assignment.mining">
                 <!-- Is civilian fleet. -->
+                <show_help custom="'Possible new civilian fleet forming.'" position="1" duration="4s" chance="100" />
+                <show_help custom="'Subordinate count is: ' + $commander.subordinates.count" position="1" duration="4s" chance="100" />
                 <do_if value="not $commander.commander? and $commander.subordinates.count == 0">
                     <!-- 1st condition: not recursive assignment: we only want to handle top-level fleet formations. -->
                     <!-- 2nd condition: fleet is a fresh fleet. -->
                     <!-- Signal our MD script to rename the fleet. -->
+                    <!--
                     <signal_objects object="player.galaxy" param="global.$v1024_symbols_requestUpdateWingName" param2="$commander" />
+                    -->
                 </do_if>
             </do_if>
         </do_if>

--- a/aiscripts/order.assign.commander.xml
+++ b/aiscripts/order.assign.commander.xml
@@ -16,7 +16,7 @@ Do:
         <do_if value="@global.$v1024_flags_fallbackModeActive and $commander.isplayerowned">
             <!-- Right click API not loaded. Prerequisite 1 satisfied. -->
             <!-- Check 1. -->
-            <do_if value="$commander.isclass.[class.ship]">
+            <do_if value="$commander.isclass.ship">
                 <!-- Is 1. Now check 2. -->
                 <set_value name="$thisship" exact="this.object" />
                 <do_if value="$commander.primarypurpose == $thisship.primarypurpose">
@@ -34,7 +34,7 @@ Do:
             </do_if>
         </do_if>
         <!-- Extra thing to do when initlaizing an empty civilian fleet. -->
-        <do_if value="$commander.isplayerowned and $commander.isclass.[class.ship]">
+        <do_if value="$commander.isplayerowned and $commander.isclass.ship">
             <!-- Assigning to ship. -->
             <do_if value="($assignmentObj == assignment.trade and $commanderObject.type != shiptype.resupplier) or $assignmentObj == assignment.mining">
                 <!-- Is civilian fleet. -->

--- a/aiscripts/order.assign.commander.xml
+++ b/aiscripts/order.assign.commander.xml
@@ -33,6 +33,19 @@ Do:
                 </do_if>
             </do_if>
         </do_if>
+        <!-- Extra thing to do when initlaizing an empty civilian fleet. -->
+        <do_if value="$commander.isplayerowned and $commander.isclass.[class.ship]">
+            <!-- Assigning to ship. -->
+            <do_if value="($assignmentObj == assignment.trade and $commanderObject.type != shiptype.resupplier) or $assignmentObj == assignment.mining">
+                <!-- Is civilian fleet. -->
+                <do_if value="not $commander.commander? and $commander.subordinates.count == 0">
+                    <!-- 1st condition: not recursive assignment: we only want to handle top-level fleet formations. -->
+                    <!-- 2nd condition: fleet is a fresh fleet. -->
+                    <!-- Signal our MD script to rename the fleet. -->
+                    <signal_objects object="player.galaxy" param="global.$v1024_symbols_requestUpdateWingName" param2="$commander" />
+                </do_if>
+            </do_if>
+        </do_if>
         <!-- We have done all we want to do. Pass back to vanilla handling. -->
     </add>
 </diff>

--- a/md/civilianfleets_signals.xml
+++ b/md/civilianfleets_signals.xml
@@ -496,47 +496,8 @@ You gotta pick the variables back up after usage!
                 </do_else>
 
                 <do_if value="global.$v1024cf_should_rename_fleets and $syncSuccessful" comment="Also update wing name when civ fleet is identified.">
-                    <!-- Confirm the Dictionary's existence -->
-                    <do_if value="not (global.$civFleets_FleetIdMapping)">
-                        <set_value name="global.$civFleets_FleetIdMapping" exact="[]" />
-                    </do_if>
-                    <!-- Confirm the counter's existence -->
-                    <do_if value="not (global.$civFleet_CurrentMaxWingID?)">
-                        <set_value name="global.$civFleet_CurrentMaxWingID" exact="0" />
-                    </do_if>
-                    <!-- Confirm that the wing commander is a known civilian fleet leader -->
-                    <set_value name="$selectedID" exact="-1" />
-                    <do_all exact="global.$civFleets_FleetIdMapping.count" counter="$i">
-                        <set_value name="$currentMapping" exact="global.$civFleets_FleetIdMapping.{$i}" />
-                        <do_if value="$fromShip == $currentMapping.{1}">
-                            <set_value name="$selectedID" exact="$currentMapping.{2}" />
-                            <break />
-                        </do_if>
-                    </do_all>
-                    <do_if value="$selectedID == -1">
-                        <!-- Brand-new civilian fleet! Getting a new ID here. -->
-                        <set_value name="global.$civFleet_WingID" exact="global.$civFleet_WingID + 1" />
-                        <set_value name="$selectedID" exact="global.$civFleet_WingID" />
-                        <append_to_list name="global.$civFleets_FleetIdMapping" exact="[$fromShip, $selectedID]" />
-                    </do_if>
-
-                    <!-- Set the correct name -->
-                    <substitute_text source="{221024, 1}" text="$cleanName">
-                        <replace string="'$ID$'" with="$selectedID" />
-                    </substitute_text>
-
-                    <!-- Determine civilian fleet appending tag -->
-                    <set_value name="$civFleet_CmdTagPairs" exact="global.$civFleet_CmdTagPairs" />
-                    <set_value name="$appendingWingName" exact="''" />
-                    <do_all exact="$civFleet_CmdTagPairs.count" counter="$i">
-                        <do_if value="($fromShip.defaultorder.id == $civFleet_CmdTagPairs.{$i}.{1})">
-                            <set_value name="$appendingWingName" exact="' %1'.[$civFleet_CmdTagPairs.{$i}.{2}]" />
-                            <break/>
-                        </do_if>
-                    </do_all>
-                    
-                    <!-- Actually setting the new fleet name -->
-                    <set_object_fleet_name object="$fromShip" name="'%1%2'.[$cleanName, $appendingWingName]" />
+                    <set_value name="$fleetLeader" exact="$fromShip" />
+                    <include_actions ref="UpdateCivilianFleetName" comment="Returns nothing, consumes $fleetLeader; updates the fleet name of the civilian fleet led by this ship." />
                 </do_if>
 
                 <!-- Out of scope variable removal -->
@@ -565,5 +526,69 @@ You gotta pick the variables back up after usage!
                 <remove_value name="$inputOrder" />
             </actions>
         </library>
+
+        <!-- Given a civilian fleet leader, updates the name of the civilian fleet it is in. -->
+        <!-- input: $fleetLeader, output: none -->
+        <library name="UpdateCivilianFleetName">
+            <actions>
+                <set_value name="$leader" exact="$fleetLeader" />
+
+                <do_if value="not (global.$civFleets_FleetIdMapping)">
+                    <set_value name="global.$civFleets_FleetIdMapping" exact="[]" />
+                </do_if>
+                <!-- Confirm the counter's existence -->
+                <do_if value="not (global.$civFleet_CurrentMaxWingID?)">
+                    <set_value name="global.$civFleet_CurrentMaxWingID" exact="0" />
+                </do_if>
+                <!-- Confirm that the wing commander is a known civilian fleet leader -->
+                <set_value name="$selectedID" exact="-1" />
+                <do_all exact="global.$civFleets_FleetIdMapping.count" counter="$i">
+                    <set_value name="$currentMapping" exact="global.$civFleets_FleetIdMapping.{$i}" />
+                    <do_if value="$leader == $currentMapping.{1}">
+                        <set_value name="$selectedID" exact="$currentMapping.{2}" />
+                        <break />
+                    </do_if>
+                </do_all>
+                <do_if value="$selectedID == -1">
+                    <!-- Brand-new civilian fleet! Getting a new ID here. -->
+                    <set_value name="global.$civFleet_WingID" exact="global.$civFleet_WingID + 1" />
+                    <set_value name="$selectedID" exact="global.$civFleet_WingID" />
+                    <append_to_list name="global.$civFleets_FleetIdMapping" exact="[$leader, $selectedID]" />
+                </do_if>
+
+                <!-- Set the correct name -->
+                <substitute_text source="{221024, 1}" text="$cleanName">
+                    <replace string="'$ID$'" with="$selectedID" />
+                </substitute_text>
+
+                <!-- Determine civilian fleet appending tag -->
+                <set_value name="$civFleet_CmdTagPairs" exact="global.$civFleet_CmdTagPairs" />
+                <set_value name="$appendingWingName" exact="''" />
+                <do_all exact="$civFleet_CmdTagPairs.count" counter="$i">
+                    <do_if value="($leader.defaultorder.id == $civFleet_CmdTagPairs.{$i}.{1})">
+                        <set_value name="$appendingWingName" exact="' %1'.[$civFleet_CmdTagPairs.{$i}.{2}]" />
+                        <break/>
+                    </do_if>
+                </do_all>
+
+                <!-- Actually setting the new fleet name -->
+                <set_object_fleet_name object="$leader" name="'%1%2'.[$cleanName, $appendingWingName]" />
+
+                <!-- Out-of-scope variable removal. -->
+                <remove_value name="$leader" />
+                <remove_value name="$fleetLeader" />
+            </actions>
+        </library>
+
+        <cue name="Signal_UpdateFleetName" instantiate="true">
+            <conditions>
+                <event_object_signalled object="player.galaxy" param="global.$v1024_symbols_requestOrderSync" />
+            </conditions>
+            <delay exact="1000s" comment="Let the game generate a fleet name for our new fleet first, and then we make changes to it. This ensures that our fleet name stick around for our new fleet."/>
+            <actions>
+                <set_value name="$fleetLeader" exact="param2" />
+                <include_actions ref="UpdateCivilianFleetName" comment="Returns nothing, consumes $fleetLeader; updates the fleet name of the civilian fleet led by this ship." />
+            </actions>
+        </cue>
     </cues>
 </mdscript>

--- a/md/civilianfleets_signals.xml
+++ b/md/civilianfleets_signals.xml
@@ -17,11 +17,11 @@ You gotta pick the variables back up after usage!
                 <set_value name="global.$v1024_symbols_requestUpdateWingName" value="'requesting update wing name'" />
 
                 <do_if value="not (global.$v1024cf_should_rename_fleets?)">
-                    <set_value name="global.$v1024cf_should_rename_fleets" exact ="true" />
+                    <set_value name="global.$v1024cf_should_rename_fleets" exact="true" />
                 </do_if>
 
                 <!-- indicate that we have loaded our mod successfully. -->
-                <set_value name="global.$v1024cf_mod_loaded" exact ="true" />
+                <set_value name="global.$v1024cf_mod_loaded" exact="true" />
             </actions>
         </cue>
 

--- a/md/civilianfleets_signals.xml
+++ b/md/civilianfleets_signals.xml
@@ -576,7 +576,7 @@ You gotta pick the variables back up after usage!
                 <!-- Given target must be a ship. -->
                 <check_value value="event.param2.isclass.ship" />
             </conditions>
-            <delay exact="1000s" comment="Let the game generate a fleet name for our new fleet first, and then we make changes to it. This ensures that our fleet name stick around for our new fleet."/>
+            <delay exact="1000ms" comment="Let the game generate a fleet name for our new fleet first, and then we make changes to it. This ensures that our fleet name stick around for our new fleet."/>
             <actions>
                 <show_help custom="'Check ' + event.param + ' || ' + global.$v1024_symbols_requestUpdateWingName" position="1" duration="2s" chance="100" chance="0" />
                 <show_help custom="'Syncing fleet name from Galactic Signal with leader = ' + event.param2.knownname + '; player age = ' + player.age" position="1" duration="2s" chance="0" />

--- a/md/civilianfleets_signals.xml
+++ b/md/civilianfleets_signals.xml
@@ -12,9 +12,9 @@ You gotta pick the variables back up after usage!
                 <event_cue_signalled cue="md.Setup.Start" />
             </conditions>
             <actions>
-                <set_value name="global.$v1024_symbols_shipDocked" value="'ship docked'" />
-                <set_value name="global.$v1024_symbols_requestOrderSync" value="'requesting order sync'" />
-                <set_value name="global.$v1024_symbols_requestUpdateWingName" value="'requesting update wing name'" />
+                <set_value name="global.$v1024_symbols_shipDocked" exact="'ship docked'" />
+                <set_value name="global.$v1024_symbols_requestOrderSync" exact="'requesting order sync'" />
+                <set_value name="global.$v1024_symbols_requestUpdateWingName" exact="'requesting update wing name'" />
 
                 <do_if value="not (global.$v1024cf_should_rename_fleets?)">
                     <set_value name="global.$v1024cf_should_rename_fleets" exact="true" />
@@ -578,8 +578,8 @@ You gotta pick the variables back up after usage!
             </conditions>
             <delay exact="1000ms" comment="Let the game generate a fleet name for our new fleet first, and then we make changes to it. This ensures that our fleet name stick around for our new fleet."/>
             <actions>
-                <show_help custom="'Check ' + event.param + ' || ' + global.$v1024_symbols_requestUpdateWingName" position="1" duration="2s" chance="100" chance="0" />
-                <show_help custom="'Syncing fleet name from Galactic Signal with leader = ' + event.param2.knownname + '; player age = ' + player.age" position="1" duration="2s" chance="0" />
+                <show_help custom="'Check ' + event.param + ' || ' + global.$v1024_symbols_requestUpdateWingName" position="1" duration="2s" chance="100" />
+                <show_help custom="'Syncing fleet name from Galactic Signal with leader = ' + event.param2.knownname + '; player age = ' + player.age" position="1" duration="2s" chance="100" />
                 <set_value name="$fleetLeader" exact="event.param2" />
                 <include_actions ref="UpdateCivilianFleetName" comment="Returns nothing, consumes $fleetLeader; updates the fleet name of the civilian fleet led by this ship." />
             </actions>

--- a/md/civilianfleets_signals.xml
+++ b/md/civilianfleets_signals.xml
@@ -582,11 +582,12 @@ You gotta pick the variables back up after usage!
 
         <cue name="Signal_UpdateFleetName" instantiate="true">
             <conditions>
-                <event_object_signalled object="player.galaxy" param="global.$v1024_symbols_requestOrderSync" />
+                <event_object_signalled object="player.galaxy" param="global.$v1024_symbols_requestUpdateWingName" />
             </conditions>
             <delay exact="1000s" comment="Let the game generate a fleet name for our new fleet first, and then we make changes to it. This ensures that our fleet name stick around for our new fleet."/>
             <actions>
-                <set_value name="$fleetLeader" exact="param2" />
+                <show_help custom="'Syncing fleet name from Galactic Signal with leader = ' + event.param2.knownname" position="1" duration="4s" chance="100" />
+                <set_value name="$fleetLeader" exact="event.param2" />
                 <include_actions ref="UpdateCivilianFleetName" comment="Returns nothing, consumes $fleetLeader; updates the fleet name of the civilian fleet led by this ship." />
             </actions>
         </cue>

--- a/md/civilianfleets_signals.xml
+++ b/md/civilianfleets_signals.xml
@@ -32,40 +32,22 @@ You gotta pick the variables back up after usage!
             param2 = fromShip
             param3 = toShip
         -->
-        <cue name="Signal_SyncOrders" instantiate="true">
+        <cue name="Signal_SyncOrders" instantiate="true" version="2">
             <conditions>
                 <event_object_signalled object="player.galaxy" param="global.$v1024_symbols_requestOrderSync" />
+                <!-- Characteristic symbol must match. -->
+                <check_value value="event.param == global.$v1024_symbols_requestOrderSync" />
+                <!-- Both targets must be non-null. -->
+                <check_value value="event.param2 != null and event.param3 != null" />
+                <!-- Both must be ships. -->
+                <check_value value="event.param2.isclass.ship and event.param3.isclass.ship" />
             </conditions>
             <delay min="100ms" max="5000ms" comment="Delay randomly to spread out the performance spike." />
             <actions>
                 <set_value name="$fromShip" exact="event.param2" />
                 <set_value name="$toShip" exact="event.param3" />
 
-                <do_if value="$fromShip == null or $toShip == null">
-                    <show_help custom="'Source and/or target be null! Cannot sync!'" position="1" duration="3s" chance="0" />
-                    <remove_value name="$fromShip" />
-                    <remove_value name="$toShip" />
-                    <cancel_cue cue="this" />
-                </do_if>
-
-                <!--
-                <show_help custom="'Tryna sync from ' + $fromShip.knownname + ' to ' + $toShip.knownname" position="1" duration="3s" />
-                -->
-
-                <do_if value="not $fromShip.isclass.ship">
-                    <show_help custom="'Source is not a ship! Improper action.'" position="1" duration="3s" chance="0" />
-                    <remove_value name="$fromShip" />
-                    <remove_value name="$toShip" />
-                    <cancel_cue cue="this" />
-                </do_if>
-                <do_if value="not $toShip.isclass.ship">
-                    <show_help custom="'Target is not a ship! Improper action.'" position="1" duration="3s" chance="0" />
-                    <remove_value name="$fromShip" />
-                    <remove_value name="$toShip" />
-                    <cancel_cue cue="this" />
-                </do_if>
-
-                <!--show_help custom="'Syncing orders from ' + $fromShip.knownname + ' to ' + $toShip.knownname" position="1" duration="4s" /-->
+                <show_help custom="'Syncing orders from ' + $fromShip.knownname + ' to ' + $toShip.knownname" position="1" duration="0.5s" chance="0" />
 
                 <!-- Caching to allow faster script execution. -->
                 <set_value name="$assignmentSkillLevel" exact="[$fromShip.pilot.skill.management, $toShip.pilot.skill.piloting].max / 3" comment="The 'skill level' designated by vanilla game, if it were to assign a ship to a station." />
@@ -580,13 +562,24 @@ You gotta pick the variables back up after usage!
             </actions>
         </library>
 
-        <cue name="Signal_UpdateFleetName" instantiate="true">
+        <!-- 
+        Given the leader of the civilian fleet, updates the fleet name.
+        The fleet name depends on the fleet type.
+            param1 = That Characteristic Symbol
+            param2 = civilian fleet leader
+        -->
+        <cue name="Signal_UpdateFleetName" instantiate="true" version="2">
             <conditions>
                 <event_object_signalled object="player.galaxy" param="global.$v1024_symbols_requestUpdateWingName" />
+                <!-- Characteristic symbol must match. -->
+                <check_value value="event.param == global.$v1024_symbols_requestUpdateWingName" />
+                <!-- Given target must be a ship. -->
+                <check_value value="event.param2.isclass.ship" />
             </conditions>
             <delay exact="1000s" comment="Let the game generate a fleet name for our new fleet first, and then we make changes to it. This ensures that our fleet name stick around for our new fleet."/>
             <actions>
-                <show_help custom="'Syncing fleet name from Galactic Signal with leader = ' + event.param2.knownname" position="1" duration="4s" chance="100" />
+                <show_help custom="'Check ' + event.param + ' || ' + global.$v1024_symbols_requestUpdateWingName" position="1" duration="2s" chance="100" chance="0" />
+                <show_help custom="'Syncing fleet name from Galactic Signal with leader = ' + event.param2.knownname + '; player age = ' + player.age" position="1" duration="2s" chance="0" />
                 <set_value name="$fleetLeader" exact="event.param2" />
                 <include_actions ref="UpdateCivilianFleetName" comment="Returns nothing, consumes $fleetLeader; updates the fleet name of the civilian fleet led by this ship." />
             </actions>


### PR DESCRIPTION
Rename the fleet afterwards if you wish to. Ignores the "no-rename" configurable option.

Slow and steady as we enhance this mod.