### PR TITLE
Add Sanity Miners to recognized fleet names

### DIFF
--- a/md/v1024_civilian_fleets.xml
+++ b/md/v1024_civilian_fleets.xml
@@ -37,6 +37,15 @@
 
         <!-- To make sub-mods for this mod, simply append to the above list after this cue is complete. -->
       </actions>
-    </cue>    
+    </cue>
+    <cue name="CivilianFleets_SanityMinersCompat" instantiate="true" version="2">
+      <conditions>
+        <event_cue_completed cue="CivilianFleets_SettingUp" />
+      </conditions>
+      <actions>
+        <!-- Compatibility with Sanity Miners -->
+        <append_to_list name="global.$civFleet_CmdTagPairs" exact="['Sanity_SectorAutoMine', {221024, 2001}]" />
+      </actions>
+    </cue>
   </cues>
 </mdscript>

--- a/md/v1024_civilian_fleets.xml
+++ b/md/v1024_civilian_fleets.xml
@@ -40,8 +40,9 @@
     </cue>
     <cue name="CivilianFleets_SanityMinersCompat" instantiate="true" version="2">
       <conditions>
-        <event_cue_completed cue="CivilianFleets_SettingUp" />
+        <event_cue_signalled cue="CivilianFleets_SettingUp" />
       </conditions>
+      <delay exat="1s" />
       <actions>
         <!-- Compatibility with Sanity Miners -->
         <append_to_list name="global.$civFleet_CmdTagPairs" exact="['Sanity_SectorAutoMine', {221024, 2001}]" />


### PR DESCRIPTION
The default "mining fleet" string shall be used to name Sanity Mining Fleets, because they are derived from the vanilla AutoMine script anyways.